### PR TITLE
Fix card blur white background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -85,6 +85,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    /* Use a dark base color so transparent elements don't show white */
+    @apply bg-black text-foreground;
   }
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -89,6 +89,7 @@ body {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    /* Match the dark background used in the pages */
+    @apply bg-black text-foreground;
   }
 }


### PR DESCRIPTION
## Summary
- ensure transparent cards have dark base by setting body background to black

## Testing
- `npm install --force`
- `npm run build` *(fails: Failed to fetch `Montserrat` from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_6876b53b57a8832092d90edc54582049